### PR TITLE
Avoid throw queryDB errors off-stack

### DIFF
--- a/src/SQLite3.js
+++ b/src/SQLite3.js
@@ -6,18 +6,17 @@ exports._newDB = function (filename, cb) {
   };
 };
 
-exports._closeDB = function (db, cb) {
+exports._closeDB = function (db) {
   return function () {
     db.close();
-    cb()();
   };
 };
 
-exports._queryDB = function (db, query, params, cb) {
+exports._queryDB = function (db, query, params, eb, cb) {
   return function () {
     db.all.apply(db, [query].concat(params.concat(function (err, rows) {
       if (err) {
-        throw err;
+        eb(err)()
       } else {
         cb(rows)();
       }

--- a/src/SQLite3.purs
+++ b/src/SQLite3.purs
@@ -2,10 +2,11 @@ module SQLite3 where
 
 import Prelude
 
-import Control.Monad.Aff (Aff, makeAff)
+import Control.Monad.Aff (Aff, Error, makeAff)
 import Control.Monad.Eff (Eff, kind Effect)
+import Data.Either (Either(..))
 import Data.Foreign (Foreign)
-import Data.Function.Uncurried (runFn4, runFn2, Fn4, Fn2)
+import Data.Function.Uncurried (Fn2, Fn5, runFn2, runFn5)
 import Data.Monoid (mempty)
 
 type FilePath = String
@@ -20,25 +21,27 @@ foreign import _newDB :: forall e.
     FilePath
     (DBConnection -> Eff (db :: DBEffects | e) Unit)
   (Eff (db :: DBEffects | e) Unit)
+
 foreign import _closeDB :: forall e.
-  Fn2
-    DBConnection
-    (Unit -> Eff (db :: DBEffects | e) Unit)
+    DBConnection ->
     (Eff (db :: DBEffects | e) Unit)
+
 foreign import _queryDB :: forall e.
-  Fn4
+  Fn5
     DBConnection
     Query
     (Array Param)
+    (Error -> Eff (db :: DBEffects | e) Unit)
     (Foreign -> Eff (db :: DBEffects | e) Unit)
   (Eff (db :: DBEffects | e) Unit)
 
 newDB :: forall e. FilePath -> Aff (db :: DBEffects | e) DBConnection
 newDB path =
   makeAff \cb -> mempty <$ runFn2 _newDB path (cb <<< pure)
-closeDB :: forall e. DBConnection -> Aff (db :: DBEffects | e) Unit
-closeDB conn =
-  makeAff \cb -> mempty <$ runFn2 _closeDB conn (cb <<< pure)
+
+closeDB :: forall e. DBConnection -> Eff (db :: DBEffects | e) Unit
+closeDB conn = _closeDB conn
+
 queryDB :: forall e. DBConnection -> Query -> Array Param -> Aff (db :: DBEffects | e) Foreign
 queryDB conn query params =
-  makeAff \cb -> mempty <$ runFn4 _queryDB conn query params (cb <<< pure)
+  makeAff \cb -> mempty <$ runFn5 _queryDB conn query params (cb <<< Left) (cb <<< Right)


### PR DESCRIPTION
Currently there's a `throwError` in the callback, causing any exceptions to be thrown off-stack. This can be avoided by handing the error back to the callback provided to us by `makeAff`.