### PR TITLE
Make closeDB return an Aff instead an Effect, like the other functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /src/.webpack.js
 .psc-ide-port
 test.sqlite3
+test-close.sqlite3
 package-lock.json

--- a/src/SQLite3.purs
+++ b/src/SQLite3.purs
@@ -9,7 +9,6 @@ module SQLite3 (
 import Prelude
 
 import Data.Either (Either(..))
-import Effect (Effect)
 import Effect.Aff (Aff, makeAff)
 import Effect.Uncurried as EU
 import Foreign (Foreign)
@@ -21,8 +20,8 @@ newDB :: FilePath -> Aff DBConnection
 newDB path =
   makeAff \cb -> mempty <$ EU.runEffectFn2 Internal._newDB path (EU.mkEffectFn1 $ cb <<< pure)
 
-closeDB :: DBConnection -> Effect Unit
-closeDB = EU.runEffectFn1 Internal._closeDB
+closeDB :: DBConnection -> Aff Unit
+closeDB conn = makeAff \cb -> mempty <$ EU.runEffectFn1 Internal._closeDB conn
 
 queryDB :: DBConnection -> Query -> Array Param -> Aff Foreign
 queryDB conn query params = makeAff \cb ->

--- a/src/SQLite3.purs
+++ b/src/SQLite3.purs
@@ -21,7 +21,10 @@ newDB path =
   makeAff \cb -> mempty <$ EU.runEffectFn2 Internal._newDB path (EU.mkEffectFn1 $ cb <<< pure)
 
 closeDB :: DBConnection -> Aff Unit
-closeDB conn = makeAff \cb -> mempty <$ EU.runEffectFn1 Internal._closeDB conn
+closeDB conn = makeAff \cb ->
+  mempty <$ EU.runEffectFn3 Internal._closeDB conn
+    (EU.mkEffectFn1 $ cb <<< Left)
+    (cb $ Right unit)
 
 queryDB :: DBConnection -> Query -> Array Param -> Aff Foreign
 queryDB conn query params = makeAff \cb ->

--- a/src/SQLite3/Internal.js
+++ b/src/SQLite3/Internal.js
@@ -4,8 +4,14 @@ exports._newDB = function(filename, cb) {
   cb(new sqlite3.Database(filename))();
 };
 
-exports._closeDB = function(db) {
-  db.close();
+exports._closeDB = function(db, eb, cb) {
+  db.close(function(err) {
+    if (err) {
+      eb(err);
+    } else {
+      cb();
+    }
+  });
 };
 
 exports._queryDB = function(db, query, params, eb, cb) {

--- a/src/SQLite3/Internal.purs
+++ b/src/SQLite3/Internal.purs
@@ -11,6 +11,7 @@ module SQLite3.Internal (
 
 import Prelude
 
+import Effect (Effect)
 import Effect.Exception (Error)
 import Effect.Uncurried as EU
 import Foreign (Foreign)
@@ -23,7 +24,12 @@ foreign import data DBConnection :: Type
 
 foreign import _newDB :: EU.EffectFn2 FilePath (EU.EffectFn1 DBConnection Unit) Unit
 
-foreign import _closeDB :: EU.EffectFn1 DBConnection Unit
+foreign import _closeDB ::
+  EU.EffectFn3
+    DBConnection
+    (EU.EffectFn1 Error Unit)
+    (Effect Unit)
+    Unit
 
 foreign import _queryDB ::
   EU.EffectFn5

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,7 +8,7 @@ import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Effect.Class (liftEffect)
 import Node.FS.Aff (exists, unlink)
-import SQLite3 (newDB, queryDB, queryObjectDB)
+import SQLite3 (closeDB, newDB, queryDB, queryObjectDB)
 import Simple.JSON (read)
 import Test.Unit (failure, suite, test)
 import Test.Unit.Assert (assert, equal)
@@ -67,3 +67,10 @@ SELECT name, detail FROM mytable
               equal a.detail "bbbb"
           Left e ->
             failure $ "row didn't deserialize correctly: " <> show e
+
+      test "we can close and re-open a database" do
+        let path = "./test-close.sqlite3"
+        cDb <- newDB path
+        closeDB cDb
+        cDb' <- newDB path
+        closeDB cDb'


### PR DESCRIPTION
Can closeDB return an `Aff`?

This would mean API users have to do less converting between `Aff` and `Effect`