### PR TITLE
Change from Param = String to Param = Foreign.

### DIFF
--- a/src/SQLite3/Internal.purs
+++ b/src/SQLite3/Internal.purs
@@ -17,7 +17,7 @@ import Foreign (Foreign)
 
 type FilePath = String
 type Query = String
-type Param = String
+type Param = Foreign
 
 foreign import data DBConnection :: Type
 


### PR DESCRIPTION
This is necessary to allow passing Node `Buffer` objects as params.

One downside is that this arguably makes the API even less type-safe, but at least it also makes the parameter types more consistent with the query return type (`Array Foreign`).

Right now I have a type-safe API at a higher level (in `purescript-querydsl`), but I guess `purescript-node-sqlite3` could have a type-safe API too. 