### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,12 +12,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "^5.0.0",
-    "purescript-foreign": "^5.0.0"
+    "purescript-aff": "^6.0.0",
+    "purescript-foreign": "^6.0.1"
   },
   "devDependencies": {
-    "purescript-test-unit": "justinwoo/purescript-test-unit#compiler/0.12",
-    "purescript-node-fs-aff": "justinwoo/purescript-node-fs-aff#compiler/0.12",
-    "purescript-simple-json": "#compiler/0.12"
+    "purescript-test-unit": "^16.0.0",
+    "purescript-node-fs-aff": "^7.0.0",
+    "purescript-simple-json": "^8.0.0"
   }
 }


### PR DESCRIPTION
This PR updates the various PureScript dependencies to their latest versions to ensure continued compatibility with the package set.

### Motivation

`node-sqlite3` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have these dependency issues resolved in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.